### PR TITLE
Adding Dynamoose to Projects using npm-to-yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To be added
 
 ## Projects using `npm-to-yarn`
 
-[Waiting for permissions]
+- [Dynamoose](https://dynamoosejs.com)
 
 ## Contributors
 


### PR DESCRIPTION
Not sure exactly how you want this section laid out. But Dynamoose is using your package on our website. Specifically on the [Install](https://dynamoosejs.com/getting_started/Install) documentation page.

Repo Link: https://github.com/dynamoose/dynamoose
Website: https://dynamoosejs.com
Page using `npm-to-yarn`: https://dynamoosejs.com/getting_started/Install
`package.json` Dependency: https://github.com/dynamoose/dynamoose/blob/8f813f7ebdd9bdc1eecf4bf174b95e7e6469a28d/docs/package.json#L14

I have turned on `Allow edits by maintainers` so feel free to push changes to my branch to modify the layout, format, etc.

Finally, looks like you were waiting for permissions prior to this. Should be clear by submitting this PR, but, I'm part of the Dynamoose organization (https://github.com/orgs/dynamoose/people), and I give permission for you to link to our project since we are using `npm-to-yarn`.