### PR TITLE
Fix issues with exact an optional in npm-to-yarn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,10 +19,10 @@ var npmToYarnTable: Indexable = {
     var ret = command
       .replace('install', 'add')
       .replace('--save-dev', '--dev')
+      .replace('--save-exact', '--exact')
+      .replace('--save-optional', '--optional')
       .replace(/\s*--save/, '')
       .replace('--no-package-lock', '--no-lockfile')
-      .replace('--save-optional', '--optional')
-      .replace('--save-exact', '--exact')
     if (/ -(?:-global|g)(?![^\b])/.test(ret)) {
       ret = ret.replace(/ -(?:-global|g)(?![^\b])/, '')
       ret = 'global ' + ret

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -33,6 +33,13 @@ describe('NPM to Yarn tests', () => {
     expect(convert('npm install', 'yarn')).toEqual('yarn install')
   })
 
+  it('npm install --save-exact', () => {
+    expect(convert('npm install --save-exact', 'yarn')).toEqual('yarn add --exact')
+  })
+  it('npm install --save-optional', () => {
+    expect(convert('npm install --save-optional', 'yarn')).toEqual('yarn add --optional')
+  })
+
   it('npm rebuild', () => {
     expect(convert('npm rebuild', 'yarn')).toEqual('yarn add --force')
   })


### PR DESCRIPTION
The conversion of --save-* arguments like --save-exact, and --save-optional must come before the
conversion of the `\s*--save` argument, otherwise the whitespace from the `install --save` is
rewritten as `install--save`.