### PR TITLE
fix: fixes chained commands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,13 @@ import { executorCommands } from './utils'
 /**
  * Converts between npm and yarn command
  */
-export default function convert (str: string, to: 'npm' | 'yarn' | 'pnpm' | 'bun'): string {
+export default function convert(str: string, to: 'npm' | 'yarn' | 'pnpm' | 'bun'): string {
+  const commands = str?.split('&&') || []
+  const converted = commands.map((str) => innerConvert(str, to).trim())
+  return converted.join(' && ')
+}
+
+function innerConvert(str: string, to: 'npm' | 'yarn' | 'pnpm' | 'bun'): string {
   if (
     str.includes('npx') ||
     str.includes('yarn dlx') ||

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -329,7 +329,32 @@ describe('NPM tests', () => {
       'pnpm pack --pack-destination foobar',
       "npm pack --pack-destination foobar\n# couldn't auto-convert command",
     ],
-  ];
+    //chaining commands
+    [
+      'npm uninstall --save-dev semver && npm install --save semver',
+      'yarn remove --dev semver && yarn add semver',
+      'pnpm remove --save-dev semver && pnpm add semver',
+      'bun remove --dev semver && bun add semver',
+    ],
+    [
+      'npm uninstall --save-dev semver&& npm install --save semver',
+      'yarn remove --dev semver && yarn add semver',
+      'pnpm remove --save-dev semver && pnpm add semver',
+      'bun remove --dev semver && bun add semver',
+    ],
+    [
+      'npm uninstall --save-dev semver &&npm install --save semver',
+      'yarn remove --dev semver && yarn add semver',
+      'pnpm remove --save-dev semver && pnpm add semver',
+      'bun remove --dev semver && bun add semver',
+    ],
+    [
+      'npm uninstall --save-dev semver&&npm install --save semver',
+      'yarn remove --dev semver && yarn add semver',
+      'pnpm remove --save-dev semver && pnpm add semver',
+      'bun remove --dev semver && bun add semver',
+    ],
+  ]
 
   describe('to Yarn', () => {
     it.each(tests)('%s', (npmValue, yarnValue) => {


### PR DESCRIPTION
This pull request enhances the command conversion logic to support chained npm commands separated by `&&`, ensuring each subcommand is properly converted to the target package manager. It also adds comprehensive test cases to verify this new behavior with various spacing patterns.

Fixes: #66 